### PR TITLE
Fixed AcquireCredentialsHandle call for PasswordCredential and added Thread.CurrentPrincipal support.

### DIFF
--- a/NSspi/Contexts/ImpersonationHandle.cs
+++ b/NSspi/Contexts/ImpersonationHandle.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Security.Principal;
+using System.Threading;
 
 namespace NSspi.Contexts
 {
@@ -29,6 +31,14 @@ namespace NSspi.Contexts
             this.disposed = false;
         }
 
+        /// <summary>
+        /// Set the current thread security context to the impersonated identity
+        /// </summary>
+        public void SetThreadIdentity()
+        {
+            Thread.CurrentPrincipal = new WindowsPrincipal(WindowsIdentity.GetCurrent(TokenAccessLevels.AllAccess));
+        }
+
         ~ImpersonationHandle()
         {
             Dispose( false );
@@ -45,7 +55,7 @@ namespace NSspi.Contexts
 
         protected virtual void Dispose( bool disposing )
         {
-            if( disposing && this.disposed == false && this.server != null && this.server.Disposed == false )
+            if ( disposing && this.disposed == false  && this.server != null && this.server.Disposed == false )
             {
                 this.server.RevertImpersonate();
             }

--- a/NSspi/Contexts/ServerContext.cs
+++ b/NSspi/Contexts/ServerContext.cs
@@ -14,6 +14,7 @@ namespace NSspi.Contexts
         private ContextAttrib finalAttribs;
 
         private bool impersonating;
+        private bool setThreadIdentity;
 
         /// <summary>
         /// Performs basic initialization of a new instance of the ServerContext class. The ServerContext
@@ -21,12 +22,14 @@ namespace NSspi.Contexts
         /// </summary>
         /// <param name="cred"></param>
         /// <param name="requestedAttribs"></param>
-        public ServerContext( Credential cred, ContextAttrib requestedAttribs ) : base( cred )
+        /// <param name="setThreadIdentity">True to automatically set the thread identity while impersonating</param>
+        public ServerContext( Credential cred, ContextAttrib requestedAttribs, bool setThreadIdentity = false ) : base( cred )
         {
             this.requestedAttribs = requestedAttribs;
             this.finalAttribs = ContextAttrib.Zero;
 
             this.impersonating = false;
+            this.setThreadIdentity = setThreadIdentity;
 
             this.SupportsImpersonate = this.Credential.PackageInfo.Capabilities.HasFlag( SecPkgCapability.Impersonation );
         }
@@ -235,6 +238,11 @@ namespace NSspi.Contexts
             else if( status != SecurityStatus.OK )
             {
                 throw new SSPIException( "Failed to impersonate the client", status );
+            }
+
+            if ( this.impersonating && this.setThreadIdentity )
+            {
+                handle.SetThreadIdentity();
             }
 
             return handle;

--- a/NSspi/Credentials/AuthData.cs
+++ b/NSspi/Credentials/AuthData.cs
@@ -50,6 +50,6 @@ namespace NSspi.Credentials
     {
         Ansi = 1,
 
-        Unicode = 1
+        Unicode = 2
     }
 }


### PR DESCRIPTION
Fixed enum value. Any actual unicode strings passed in will only use the first character because the 0 byte after the first character is treated as a terminator.

Added ability to set the current thread principal so it's inline with the actual security context.