### PR TITLE
Added option to encrypt/decrypt data without embedding buffer lengths

### DIFF
--- a/NSspi/SecureBuffer/SecureBuffer.cs
+++ b/NSspi/SecureBuffer/SecureBuffer.cs
@@ -52,7 +52,7 @@ namespace NSspi.Buffers
         {
             this.Buffer = buffer;
             this.Type = type;
-            this.Length = this.Buffer.Length;
+            this.Length = this.Buffer?.Length ?? 0;
         }
 
         /// <summary>

--- a/NSspi/SecureBuffer/SecureBufferAdapter.cs
+++ b/NSspi/SecureBuffer/SecureBufferAdapter.cs
@@ -123,7 +123,7 @@ namespace NSspi.Buffers
 
                 this.bufferCarrier[i] = new SecureBufferInternal();
                 this.bufferCarrier[i].Type = this.buffers[i].Type;
-                this.bufferCarrier[i].Count = this.buffers[i].Buffer.Length;
+                this.bufferCarrier[i].Count = this.buffers[i].Buffer?.Length ?? 0;
                 this.bufferCarrier[i].Buffer = bufferHandles[i].AddrOfPinnedObject();
             }
 
@@ -135,6 +135,23 @@ namespace NSspi.Buffers
             this.descriptor.Buffers = bufferCarrierHandle.AddrOfPinnedObject();
 
             this.descriptorHandle = GCHandle.Alloc( descriptor, GCHandleType.Pinned );
+        }
+
+        /// <summary>
+        /// Extracts data from a buffer allocated by the platform
+        /// </summary>
+        /// <remarks>
+        /// If a buffer is allocated by the platform, the original .NET byte[] would be <c>null</c> and so can't
+        /// be read directly by the caller. This method extracts the data from the unmanaged buffer and copies it
+        /// to managed memory so it can be used easily.
+        /// </remarks>
+        /// <param name="index">The index of the buffer to extract the data from</param>
+        /// <returns>The data in the buffer</returns>
+        public byte[] ExtractData(int index)
+        {
+            byte[] buf = new byte[this.bufferCarrier[index].Count];
+            Marshal.Copy( this.bufferCarrier[index].Buffer, buf, 0, this.bufferCarrier[index].Count );
+            return buf;
         }
 
         [ReliabilityContract( Consistency.WillNotCorruptState, Cer.Success )]

--- a/NsspiDemo/Program.cs
+++ b/NsspiDemo/Program.cs
@@ -137,6 +137,30 @@ namespace NSspi
                     }
                 }
 
+                cipherText = client.Encrypt(plainText, true);
+
+                roundTripPlaintext = server.Decrypt(cipherText, true);
+
+                if (roundTripPlaintext.Length != plainText.Length)
+                {
+                    throw new Exception();
+                }
+
+                for (int i = 0; i < plainText.Length; i++)
+                {
+                    if (plainText[i] != roundTripPlaintext[i])
+                    {
+                        throw new Exception();
+                    }
+                }
+
+                rtMessage = Encoding.UTF8.GetString(roundTripPlaintext, 0, roundTripPlaintext.Length);
+
+                if (rtMessage.Equals(message) == false)
+                {
+                    throw new Exception();
+                }
+
                 Console.Out.Flush();
             }
             finally


### PR DESCRIPTION
I'm using this library to create a .NET Core client for a WCF server using WS-Trust with SSPI authentication. The tokens generated by the WCF server contain data encrypted by SSPI but without the lengths of the individual buffers encoded in the output, as expected by this library.

In order to decrypt these tokens I've extended the `Encrypt` and `Decrypt` methods with extra overloads to handle data in this format.